### PR TITLE
docs: how to request access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # .github
-Organization profile visible publicly
+
+This repository contains the public profile for this GitHub organization. See [Customizing your organization's profile](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile).
+
+The [/profile/README](./profile/README.md) contains the content that will be displayed to users that navigate to this organization, but do not have memberships.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,12 @@
+## Hi there 👋
+
+<!--
+
+**Here are some ideas to get you started:**
+
+🙋‍♀️ A short introduction - what is your organization all about?
+🌈 Contribution guidelines - how can the community get involved?
+👩‍💻 Useful resources - where can the community find your docs? Is there anything else the community should know?
+🍿 Fun facts - what does your team eat for breakfast?
+🧙 Remember, you can do mighty things with the power of [Markdown](https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
+-->

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,12 +1,20 @@
-## Hi there 👋
+# Welcome to Mondelez-Middleware
 
-<!--
+This private GitHub organization is part of the Mondelez enterprise. If you are seeing this page, you are not a member of the organization (or are not currently authenticated.). See below for requesting organization access
 
-**Here are some ideas to get you started:**
+## Requesting Access
 
-🙋‍♀️ A short introduction - what is your organization all about?
-🌈 Contribution guidelines - how can the community get involved?
-👩‍💻 Useful resources - where can the community find your docs? Is there anything else the community should know?
-🍿 Fun facts - what does your team eat for breakfast?
-🧙 Remember, you can do mighty things with the power of [Markdown](https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
--->
+### Prequisites
+
+- You must have a Mondelez International user account
+- You must have a GitHub account. This can be an existing account, or one that you create specifically for use in this organization.
+- You must link your Mondelez email address [to your GitHub Account](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/adding-an-email-address-to-your-github-account).
+  - If you have an `@mdlz.com` email address, use it for this step.
+  - Some contractors may not have an `@mdlz.com` email account. Emails related to their Mondelez user account are sent to a third-party email address instead. In this scenario, that email must be used.
+
+### Submit Request and Join Organization
+
+1. Go to **Access Center**
+2. In *Manage User Access*, request the `Mondelez Middleware Github Access` entitlement for your account and submit the request.
+3. After your request is approved, you will receive an email invitation to join the organization. This will be sent from [noreply@github.com](noreply@github.com) with the subject line: `@MDLZGithub has invited you to join the @Mondelez-Middleware organization`
+4. Click `Join @Mondelez-Middlware`, and follow the prompts to authenticate to Mondelez SSO and link your account to the GitHub organization.


### PR DESCRIPTION
In the absence of a larger documentation repository, adding access request guidance to the public profile, similar to what we've done [here](https://docs.cloud.mdlz.com/developers/getting-started.html#requesting-github-in-access-center) and [here](https://mulesoft.docs.cloud.mdlz.com/developer-wiki/onboarding/access/github.html)